### PR TITLE
Added subscription url_option for vignette system in Europe

### DIFF
--- a/WazeRouteCalculator/WazeRouteCalculator.py
+++ b/WazeRouteCalculator/WazeRouteCalculator.py
@@ -136,7 +136,12 @@ class WazeRouteCalculator(object):
         }
         if self.vehicle_type:
             url_options["vehicleType"] = self.vehicle_type
-
+        # Handle vignette system in Europe
+        if 'AVOID_TOLL_ROADS' in self.route_options:
+            pass #don't want to do anything if we're avoiding toll roads
+        else:
+            url_options["subscription"] = "*"
+            
         response = requests.get(self.WAZE_URL + routing_server, params=url_options, headers=self.HEADERS)
         response.encoding = 'utf-8'
         response_json = self._check_response(response)


### PR DESCRIPTION
Added subscription url_option for vignette system in Europe
When avoid_toll_roads is set, we don't need anything, but if it isn't, we need to add a url_option which specifies we have all vignettes (or toll-pass stickers).
The possibility to replace subscription=* with one or more subscription=vignette-country url_options is there for the future, but for now, allowing all is what I needed.